### PR TITLE
BaidieProcessor里面写一个通用的处理文件进行计算的方法

### DIFF
--- a/ruoyi-admin/src/main/java/com/ruoyi/web/controller/system/ABCAnalyseController.java
+++ b/ruoyi-admin/src/main/java/com/ruoyi/web/controller/system/ABCAnalyseController.java
@@ -32,7 +32,7 @@ public class ABCAnalyseController {
     public AjaxResult importData(MultipartFile file, boolean updateSupport, HttpServletRequest request)
     {
         try {
-            final Map<String, List<?>> resultKeyToDataArrays = BaidieProcessor.importFileForGroupOne(file);
+            final Map<String, List<?>> resultKeyToDataArrays = BaidieProcessor.importABCGroupOne(file);
             final JSONObject json = BaidieUtils.generateResponseJson(resultKeyToDataArrays);
 
             return AjaxResult.success(json);

--- a/ruoyi-admin/src/main/resources/templates/system/project1/ass3/abc/index.html
+++ b/ruoyi-admin/src/main/resources/templates/system/project1/ass3/abc/index.html
@@ -1077,7 +1077,6 @@
                     interval: 0,
                     fontSize: 12,
                     formatter: function (value) {
-                        debugger
                         var ret = "";//拼接加\n返回的类目项
                         var maxLength = 4;//每项显示文字个数
                         value = parseInt(value.substring(0, 3));
@@ -1295,7 +1294,6 @@
                         interval: 0,
                         fontSize: 12,
                         formatter: function (value) {
-                            debugger
                             var ret = "";//拼接加\n返回的类目项
                             var maxLength = 2;//每项显示文字个数
                             value = parseInt(value.substring(0, 3));
@@ -1513,7 +1511,6 @@
                         interval: 0,
                         fontSize:12,
                         formatter: function (value) {
-                            debugger
                             var ret = "";//拼接加\n返回的类目项
                             var maxLength = 2;//每项显示文字个数
                             value = parseInt(value.substring(0, 3));
@@ -1681,9 +1678,7 @@
             showRefresh: false,
             showExport: true,
             exportTypes: ['excel','txt','xml'],
-            columns: [{
-                checkbox: true
-            },
+            columns: [
                 {
                     field: '物料编码',
                     title: '物料编码'

--- a/ruoyi-admin/src/test/java/com/ruoyi/baidie/BaidieProcessorTest.java
+++ b/ruoyi-admin/src/test/java/com/ruoyi/baidie/BaidieProcessorTest.java
@@ -5,13 +5,19 @@ import com.ruoyi.web.controller.system.ABCAnalyseController;
 import org.junit.Test;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import static java.util.Map.entry;
 import static org.junit.Assert.assertEquals;
 
 public class BaidieProcessorTest {
@@ -23,7 +29,7 @@ public class BaidieProcessorTest {
                 "text/plain",
                 "some kml".getBytes());
         try {
-            BaidieProcessor.importFileForGroupOne(mockFile);
+            BaidieProcessor.importABCGroupOne(mockFile);
         } catch (IOException e) {
             assertEquals(
                     e.getMessage(),
@@ -42,7 +48,7 @@ public class BaidieProcessorTest {
                 "abc_first_upload_table.xls",
                 MediaType.APPLICATION_XML_VALUE,
                 Files.newInputStream(Paths.get(path)));
-        Map<String, List<?>> resultMap = BaidieProcessor.importFileForGroupOne(mockMultipartFile);
+        Map<String, List<?>> resultMap = BaidieProcessor.importABCGroupOne(mockMultipartFile);
 
         // Test that the result keyset is data1 and data2.
         assertEquals(resultMap.keySet(), ImmutableSet.of("data1", "data2"));
@@ -209,5 +215,65 @@ public class BaidieProcessorTest {
         assertEquals("4705461", data4Entries.get(4).getMaterialCode());
         assertEquals(14, data4Entries.get(4).getOutboundQuantity(), 0.1);
         assertEquals(1131, data4Entries.get(4).getCumulativeOutboundQuantity(), 0.1);
+    }
+
+    // 测试这个通用方法。
+    // 这是一个private static 方法，通常情况下不应该直接测试这个private方法，可是基于这个方法会被所有上传功能的实现
+    // 所调用，这里做一个例外的直接测试。
+    @Test
+    public void testImportTemplateMethod() throws Exception {
+        final String path = "src/test/resources/abc_first_upload_table.xls";
+        MockMultipartFile mockMultipartFile
+                = new MockMultipartFile(
+                "xlsFile",
+                "abc_first_upload_table.xls",
+                MediaType.APPLICATION_XML_VALUE,
+                Files.newInputStream(Paths.get(path)));
+
+        // 通过reflection来得到需要被测试的private函数。
+        Method importTemplateMethod =
+                BaidieProcessor.class.getDeclaredMethod(
+                        "importFromFileAndProcess",
+                        MultipartFile.class,
+                        Class.class,
+                        String.class,
+                        Map.class);
+        importTemplateMethod.setAccessible(true);
+
+        // 构造一个keyToCalculator Map来做任意基于List<Data5Entry>的计算。
+        Map<String, Function<List<ABCAnalyseController.Data1Entry>, List<?>>> keyToCalculator =
+                Map.ofEntries(
+                        entry("inputSizeCalculator", // 返回一个大小为1的List，里面是输入的List的大小
+                                data1Entries ->  List.of(data1Entries.size())),
+                        entry("materialCodeCalculator",  // 返回一个跟输入大小一样的List，里面是输入的物料编码。
+                                data1Entries -> data1Entries.stream()
+                                        .map(ABCAnalyseController.Data1Entry::getMaterialCode)
+                                        .collect(Collectors.toList())),
+                        entry("firstAndLastCalculator",  // 返回第一个List,里面由输入的第一个和最后一个数据。
+                                data1Entries ->
+                                        Arrays.asList(
+                                                data1Entries.get(0),
+                                                data1Entries.get(data1Entries.size() - 1)))
+        );
+        Map<String, List<?>> result = (Map<String, List<?>>) importTemplateMethod.invoke(
+                null,
+                mockMultipartFile,
+                ABCAnalyseController.Data1Entry.class,
+                "inputKey",
+                keyToCalculator
+                );
+
+        // 首先结果为 1 + keyToCalculator.size() 输入加所有的计算结果。
+        assertEquals(keyToCalculator.size() + 1, result.size());
+
+        // 检查calculator的结果: 输入数据有11行。
+        assertEquals(1, result.get("inputSizeCalculator").size());
+        assertEquals(11, result.get("inputSizeCalculator").get(0));
+
+        // 检查第二个计算器的结果。
+        assertEquals(11, result.get("materialCodeCalculator").size());
+
+        // 检查第三个计算器的结果。
+        assertEquals(2, result.get("firstAndLastCalculator").size());
     }
 }


### PR DESCRIPTION
这个方法可以用于所有上传功能，不受计算的输入输出限制。
可通用于ABC, EIQ，PCB等等等等。

传入一下参数：

> 
>                 importFile,      // 输入文件
>                 ABCAnalyseController.Data5Entry.class,  // 输入文件里数据的类型
>                 "data5",    // 输入数据在返回的Map里面的查找键(key)
>                 Map.of("data3", ABCClassifier::sortByOutboundFrequency)  // 对输入数据进行N个运算，每个运算结果储存到返回Map里面的对应的查找键里面
>);